### PR TITLE
Sort whole line comments, instead of removing them

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", 3.11, 3.12]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - name: Install uv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,15 +24,12 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
+
+      - name: Install uv and set the python version
+        uses: astral-sh/setup-uv@v5
         with:
-          version: "latest"
-      - name: Set up Python ${{ matrix.python-version }}
-        run: uv python install ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: uv sync --frozen
       - name: Run tests
         run: uv run pytest
-      - name: Check dependencies are sorted
-        run: uv run uv-sort --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,14 +10,15 @@ jobs:
         python-version: ["3.9", "3.10", 3.11, 3.12]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-      - run: pip install -r requirements.txt
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cache/uv
-          key: uv-${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}
-      - run: uv sync --frozen
-      - run: uv run pytest
+          version: "latest"
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: uv sync --frozen
+      - name: Run tests
+        run: uv run pytest
+      - name: Check dependencies are sorted
+        run: uv run uv-sort --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,20 @@ name: Test
 on: ["pull_request", "push"]
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+      - name: Set up Python
+        run: uv python install 3.12
+      - name: Install dependencies
+        run: uv sync --frozen
+      - uses: pre-commit/action@v3.0.1
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: uv-lock
 
   - repo: https://github.com/ninoseki/uv-sort
-    rev: v0.5.0
+    rev: v0.6.0
     hooks:
       - id: uv-sort
         files: ^(pyproject\.toml)$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,9 @@ version = "{version}"
 [tool.uv]
 dev-dependencies = [
     "pre-commit>=4.2.0",
-    "pytest>=8.3.5",
     "pytest-pretty>=1.2.0",
     "pytest-randomly>=3.16.0",
+    "pytest>=8.3.5",
 ]
 
 [project.scripts]

--- a/src/uv_sort/cli.py
+++ b/src/uv_sort/cli.py
@@ -28,7 +28,7 @@ def sort(
         typer.Option(
             "--check",
             "-c",
-            help="Check if dependencies are sorted and exit with a non-zero status code when they are not.",  # noqa: E501
+            help="Check if dependencies are sorted and exit with a non-zero status code when they are not.",
         ),
     ] = False,
 ):

--- a/src/uv_sort/main.py
+++ b/src/uv_sort/main.py
@@ -89,7 +89,7 @@ def sort_array_by_name(x: Array) -> Array:
     grouped_items: list[tuple[list[_ArrayItemGroup], _ArrayItemGroup]] = []
     preceding_comments: list[_ArrayItemGroup] = []
     trailing_comments: list[_ArrayItemGroup] = []
-    
+
     for item in x._value:
         if is_standalone_comment(item):
             # Accumulate standalone comments
@@ -99,27 +99,28 @@ def sort_array_by_name(x: Array) -> Array:
             grouped_items.append((preceding_comments.copy(), item))
             preceding_comments.clear()
         # Skip other non-processable items (whitespace, etc.)
-    
+
     # Any remaining comments are trailing comments
     trailing_comments = preceding_comments
-    
+
     # Sort the grouped items by the dependency value
     _sorted = sorted(grouped_items, key=lambda group: key_builder(group[1]))
-    
+
     # Flatten the sorted groups back into a list
     flattened: list[_ArrayItemGroup] = []
     for comments, item in _sorted:
         flattened.extend(comments)
         flattened.append(item)
-    
+
     # Add trailing comments at the end
     flattened.extend(trailing_comments)
-    
-    # rebuild the array with preserving comments & indentation
-    # consider adding a line-break at last if the last indent has a line-break
+
+    # No data to process or sort
     if not flattened:
         return x
-        
+
+    # rebuild the array with preserving comments & indentation
+    # consider adding a line-break at last if the last indent has a line-break
     last_indent = flattened[-1].indent
     has_line_break_at_last = (
         last_indent.as_string() if last_indent else ""

--- a/src/uv_sort/main.py
+++ b/src/uv_sort/main.py
@@ -20,6 +20,11 @@ def is_processable(item: _ArrayItemGroup) -> bool:
     return not isinstance(item.value, (Comment, Whitespace, Null))
 
 
+def is_standalone_comment(item: _ArrayItemGroup) -> bool:
+    """Check if an item is a standalone comment (Null with comment attached)"""
+    return isinstance(item.value, Null) and item.comment is not None
+
+
 def key_builder(item: _ArrayItemGroup) -> str:
     return str(item.value).casefold()
 
@@ -49,6 +54,16 @@ def multi_line_array_mapper(item: _ArrayItemGroup, *, indent: str, **kwargs) -> 
     if item.value is None:
         return ""
 
+    # Handle standalone comments (Null with comment)
+    if is_standalone_comment(item):
+        return "".join(
+            [
+                indent,
+                item.indent.as_string() if item.indent else "",
+                item.comment.as_string() if item.comment else "",
+            ]
+        )
+
     # always add a comma at the end of the line
     comma = item.comma.as_string() if item.comma else ""
     if not comma.strip().endswith(","):
@@ -70,15 +85,42 @@ def sort_array_by_name(x: Array) -> Array:
         # nothing to sort
         return x
 
-    # reject ArrayItemGroup doesn't have a value (e.g. trailing ",", comment)
-    filtered: list[_ArrayItemGroup] = [
-        item for item in x._value if is_processable(item)
-    ]
-    # sort the array
-    _sorted = sorted(filtered, key=key_builder)
+    # Group items with their preceding standalone comments
+    grouped_items: list[tuple[list[_ArrayItemGroup], _ArrayItemGroup]] = []
+    preceding_comments: list[_ArrayItemGroup] = []
+    trailing_comments: list[_ArrayItemGroup] = []
+    
+    for item in x._value:
+        if is_standalone_comment(item):
+            # Accumulate standalone comments
+            preceding_comments.append(item)
+        elif is_processable(item):
+            # This is a real dependency, group it with any preceding comments
+            grouped_items.append((preceding_comments.copy(), item))
+            preceding_comments.clear()
+        # Skip other non-processable items (whitespace, etc.)
+    
+    # Any remaining comments are trailing comments
+    trailing_comments = preceding_comments
+    
+    # Sort the grouped items by the dependency value
+    _sorted = sorted(grouped_items, key=lambda group: key_builder(group[1]))
+    
+    # Flatten the sorted groups back into a list
+    flattened: list[_ArrayItemGroup] = []
+    for comments, item in _sorted:
+        flattened.extend(comments)
+        flattened.append(item)
+    
+    # Add trailing comments at the end
+    flattened.extend(trailing_comments)
+    
     # rebuild the array with preserving comments & indentation
     # consider adding a line-break at last if the last indent has a line-break
-    last_indent = _sorted[-1].indent
+    if not flattened:
+        return x
+        
+    last_indent = flattened[-1].indent
     has_line_break_at_last = (
         last_indent.as_string() if last_indent else ""
     ).startswith("\n")
@@ -91,10 +133,10 @@ def sort_array_by_name(x: Array) -> Array:
         mapper(
             item,
             first=index == 0,
-            last=index == len(_sorted) - 1,
+            last=index == len(flattened) - 1,
             indent=x.trivia.indent,
         )
-        for index, item in enumerate(_sorted)
+        for index, item in enumerate(flattened)
     ]
 
     s = "[" + "".join(mapped) + x.trivia.indent + last_line_break + "]"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from textwrap import dedent
 
 import pytest
 from tomlkit import array
@@ -53,12 +54,13 @@ def test_sort_from_file(tmp_path):
     """Test the sort function that reads from a file path"""
     from uv_sort.main import sort
 
-    toml_content = """[project]
-dependencies = [
-    "zebra",
-    "alpha",
-]
-"""
+    toml_content = dedent("""\
+        [project]
+        dependencies = [
+            "zebra",
+            "alpha",
+        ]
+        """)
 
     test_file = tmp_path / "test.toml"
     test_file.write_text(toml_content)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -21,12 +21,51 @@ from uv_sort.main import sort_array_by_name, sort_toml_project
             '["dvc-pandas>=0.3.3", "dvc[azure]>=3.59.2", "uv-sort>=0.5.1"]',
             '["dvc-pandas>=0.3.3", "dvc[azure]>=3.59.2", "uv-sort>=0.5.1"]',
         ),
+        # standalone comments should be preserved with their following dependency
+        (
+            '[\n"zoo",\n# comment about bar\n"bar",\n"foo",\n]',
+            '[\n# comment about bar\n"bar",\n"foo",\n"zoo",\n]',
+        ),
+        # multiple standalone comments should stay together
+        (
+            '[\n"zoo",\n# first comment\n# second comment\n"bar",\n]',
+            '[\n# first comment\n# second comment\n"bar",\n"zoo",\n]',
+        ),
+        # mixed inline and standalone comments
+        (
+            '[\n"zoo", # inline comment\n# standalone comment\n"bar",\n"foo", # another inline\n]',
+            '[\n# standalone comment\n"bar",\n"foo", # another inline\n"zoo", # inline comment\n]',
+        ),
+        # trailing comments should be preserved
+        (
+            '[\n"zoo",\n"bar",\n# trailing comment\n]',
+            '[\n"bar",\n"zoo",\n# trailing comment\n]',
+        ),
     ],
 )
 def test_sort_array_by_name(raw: str, expected: str):
     arr = array(raw)
     _sorted = sort_array_by_name(arr)
     assert _sorted.as_string() == expected
+
+
+def test_sort_from_file(tmp_path):
+    """Test the sort function that reads from a file path"""
+    from uv_sort.main import sort
+    
+    toml_content = """[project]
+dependencies = [
+    "zebra",
+    "alpha",
+]
+"""
+    
+    test_file = tmp_path / "test.toml"
+    test_file.write_text(toml_content)
+    
+    result = sort(test_file)
+    assert "alpha" in result
+    assert "zebra" in result
 
 
 @pytest.fixture

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -52,17 +52,17 @@ def test_sort_array_by_name(raw: str, expected: str):
 def test_sort_from_file(tmp_path):
     """Test the sort function that reads from a file path"""
     from uv_sort.main import sort
-    
+
     toml_content = """[project]
 dependencies = [
     "zebra",
     "alpha",
 ]
 """
-    
+
     test_file = tmp_path / "test.toml"
     test_file.write_text(toml_content)
-    
+
     result = sort(test_file)
     assert "alpha" in result
     assert "zebra" in result

--- a/tests/test_standalone_comments.py
+++ b/tests/test_standalone_comments.py
@@ -1,0 +1,242 @@
+"""Test standalone comment preservation functionality"""
+
+from textwrap import dedent
+
+import pytest
+import tomlkit
+
+from uv_sort.main import sort_toml_project
+
+
+@pytest.mark.parametrize(
+    "test_name, input_toml, expected_toml",
+    [
+        (
+            "basic_standalone_comment",
+            dedent("""\
+                [project]
+                dependencies = [
+                    "zoo",
+                    # This comment is about bar
+                    "bar",
+                    "apple",
+                ]
+                """),
+            dedent("""\
+                [project]
+                dependencies = [
+                    "apple",
+                    # This comment is about bar
+                    "bar",
+                    "zoo",
+                ]
+                """),
+        ),
+        (
+            "multiple_comments_for_one_dependency",
+            dedent("""\
+                [project]
+                dependencies = [
+                    "zebra",
+                    # First comment about alpha
+                    # Second comment about alpha
+                    # Third comment about alpha
+                    "alpha",
+                    "beta",
+                ]
+                """),
+            dedent("""\
+                [project]
+                dependencies = [
+                    # First comment about alpha
+                    # Second comment about alpha
+                    # Third comment about alpha
+                    "alpha",
+                    "beta",
+                    "zebra",
+                ]
+                """),
+        ),
+        (
+            "mixed_inline_and_standalone",
+            dedent("""\
+                [project]
+                dependencies = [
+                    "zebra",  # inline comment for zebra
+                    # standalone comment for alpha
+                    "alpha",
+                    "gamma",  # inline comment for gamma
+                    # standalone comment for beta
+                    "beta",  # also has inline comment
+                ]
+                """),
+            dedent("""\
+                [project]
+                dependencies = [
+                    # standalone comment for alpha
+                    "alpha",
+                    # standalone comment for beta
+                    "beta",  # also has inline comment
+                    "gamma",  # inline comment for gamma
+                    "zebra",  # inline comment for zebra
+                ]
+                """),
+        ),
+        (
+            "dev_dependencies",
+            dedent("""\
+                [tool.uv]
+                dev-dependencies = [
+                    "ruff",
+                    # For testing with coverage
+                    "pytest-cov",
+                    # For basic testing
+                    "pytest",
+                ]
+                """),
+            dedent("""\
+                [tool.uv]
+                dev-dependencies = [
+                    # For basic testing
+                    "pytest",
+                    # For testing with coverage
+                    "pytest-cov",
+                    "ruff",
+                ]
+                """),
+        ),
+        (
+            "optional_dependencies",
+            dedent("""\
+                [project.optional-dependencies]
+                docs = [
+                    "sphinx",
+                    # Theme for documentation
+                    "sphinx-rtd-theme",
+                    "myst-parser",
+                ]
+                """),
+            dedent("""\
+                [project.optional-dependencies]
+                docs = [
+                    "myst-parser",
+                    "sphinx",
+                    # Theme for documentation
+                    "sphinx-rtd-theme",
+                ]
+                """),
+        ),
+        (
+            "dependency_groups",
+            dedent("""\
+                [dependency-groups]
+                test = [
+                    "pytest",
+                    # Coverage tool
+                    "coverage",
+                    "hypothesis",
+                ]
+                """),
+            dedent("""\
+                [dependency-groups]
+                test = [
+                    # Coverage tool
+                    "coverage",
+                    "hypothesis",
+                    "pytest",
+                ]
+                """),
+        ),
+        (
+            "trailing_comments",
+            dedent("""\
+                [project]
+                dependencies = [
+                    "zebra",
+                    "alpha",
+                    # This is a trailing comment
+                    # Second trailing comment
+                ]
+                """),
+            dedent("""\
+                [project]
+                dependencies = [
+                    "alpha",
+                    "zebra",
+                    # This is a trailing comment
+                    # Second trailing comment
+                ]
+                """),
+        ),
+    ],
+)
+def test_standalone_comment_preservation(
+    test_name: str, input_toml: str, expected_toml: str
+):
+    """Test that standalone comments are preserved and stay with their following dependency"""
+    sorted_doc = sort_toml_project(input_toml)
+    result = tomlkit.dumps(sorted_doc)
+    assert result == expected_toml, f"Failed test: {test_name}"
+
+
+def test_complex_scenario():
+    """Test a complex scenario with various comment types"""
+    input_toml = dedent("""\
+        [project]
+        name = "test-project"
+        dependencies = [
+            "requests",  # HTTP library
+            # Database dependencies
+            # These are critical for the app
+            "sqlalchemy",
+            "psycopg2",  # PostgreSQL adapter
+            # Web framework and extensions
+            "flask",
+            # Authentication
+            # Used for user management
+            # Very important!
+            "flask-login",
+            "werkzeug",  # WSGI utilities
+        ]
+
+        [tool.uv]
+        dev-dependencies = [
+            # Testing tools
+            "pytest",
+            # Code quality
+            "black",
+            "ruff",  # Fast linter
+        ]
+        """)
+
+    expected_toml = dedent("""\
+        [project]
+        name = "test-project"
+        dependencies = [
+            # Web framework and extensions
+            "flask",
+            # Authentication
+            # Used for user management
+            # Very important!
+            "flask-login",
+            "psycopg2",  # PostgreSQL adapter
+            "requests",  # HTTP library
+            # Database dependencies
+            # These are critical for the app
+            "sqlalchemy",
+            "werkzeug",  # WSGI utilities
+        ]
+
+        [tool.uv]
+        dev-dependencies = [
+            # Code quality
+            "black",
+            # Testing tools
+            "pytest",
+            "ruff",  # Fast linter
+        ]
+        """)
+
+    sorted_doc = sort_toml_project(input_toml)
+    result = tomlkit.dumps(sorted_doc)
+    assert result == expected_toml


### PR DESCRIPTION
We have comments on their own line, above the packages they apply to like:
```toml
  dependencies = [
      "zoo",
      # This comment is about bar
      "bar",
      "apple",
  ]
```

And we need to keep these comments in the right place, when re-ordering.

I've also converted the test workflow to use uv, and check the pre-commit hooks are successful.